### PR TITLE
Remove `hev1.*` for MediaRecorder

### DIFF
--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
@@ -64,7 +64,7 @@ bool MediaRecorderPrivateAVFImpl::isTypeSupported(Document& document, ContentTyp
                 && !(codec.startsWith("av01."_s) && document.settings().webRTCAV1CodecEnabled())
 #endif
 #if ENABLE(WEB_RTC)
-                && !((codec.startsWith("hev1."_s) || codec.startsWith("hvc1."_s)) && document.settings().webRTCH265CodecEnabled())
+                && !(codec.startsWith("hvc1."_s) && document.settings().webRTCH265CodecEnabled())
 #endif
 #if HAVE(AVASSETWRITER_WITH_OPUS_SUPPORTED)
                 && codec != "opus"_s

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp
@@ -113,10 +113,10 @@ static String codecStringForMediaVideoCodecId(FourCharCode codec)
     switch (codec) {
     case 'vp08': return "vp8"_s;
     case kCMVideoCodecType_VP9: return "vp09.00.10.08"_s; // vp9, profile 0, level 1.0, 8 bits, "VideoRange"
-    case 'vp92': return "vp09.02.30.10"_s; // vp9, profile 0, level 1.0, 10 bits, "VideoRange"
+    case 'vp92': return "vp09.02.30.10"_s; // vp9, profile 2, level 1.0, 10 bits, "VideoRange"
     case kCMVideoCodecType_AV1: return "av01.0.01M.08"_s; // av01, "Main", "Level_2_1", "Main", 8 bits, "VideoRange";
     case kCMVideoCodecType_H264: return "avc1.42000a"_s; // AVC Baseline Level 1
-    case kCMVideoCodecType_HEVC: return "hev1.1.6.L93.B0"_s; // HEVC progressive, non-packed stream, Main Profile, Main Tier, Level 3.1
+    case kCMVideoCodecType_HEVC: return "hvc1.1.6.L93.B0"_s; // HEVC progressive, non-packed stream, Main Profile, Main Tier, Level 3.1
     case kAudioFormatMPEG4AAC: return "mp4a.40.2"_s;
     case kAudioFormatOpus: return "opus"_s;
     case kAudioFormatLinearPCM: return "pcm"_s;
@@ -170,7 +170,7 @@ bool MediaRecorderPrivateEncoder::initialize(const MediaRecorderPrivateOptions& 
             m_audioCodec = kAudioFormatAppleLossless;
         else if (startsWithLettersIgnoringASCIICase(codec, "avc1"_s))
             m_videoCodec = kCMVideoCodecType_H264;
-        else if (!isWebM && (codec.startsWith("hev1."_s) || codec.startsWith("hvc1."_s)))
+        else if (!isWebM && codec.startsWith("hvc1."_s))
             m_videoCodec = kCMVideoCodecType_HEVC;
         else if (!isWebM && codec.startsWith("av01.0"_s))
             m_videoCodec = kCMVideoCodecType_AV1;


### PR DESCRIPTION
#### 2bf9201c8d19e82a234d683da1eac1e66b73f6e2
<pre>
Remove `hev1.*` for MediaRecorder
<a href="https://bugs.webkit.org/show_bug.cgi?id=292543">https://bugs.webkit.org/show_bug.cgi?id=292543</a>

Reviewed by NOBODY (OOPS!).

Currently, MediaRecorder incorrectly reports that it
supports both `hev1` and `hvc1` codec tags. However,
based on the implementation, WebKit actually only
supports `hvc1` instead of `hev1`. The correct fix
is to remove `hev1` from the support list until WebKit
actually needs to support `hev1` in the future.

* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp:
(WebCore::MediaRecorderPrivateAVFImpl::isTypeSupported):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::codecStringForMediaVideoCodecId):
(WebCore::MediaRecorderPrivateEncoder::initialize):
</pre>